### PR TITLE
Add host-side USB reader for Pico measurement stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,67 @@
-# Introduction 
-TODO: Give a short introduction of your project. Let this section explain the objectives or the motivation behind this project. 
+# Introduction
+
+This repository contains two closely related pieces of software for working with an
+Infineon TLV493D-A1B6 3D Hall sensor:
+
+* **Firmware** for the Raspberry Pi Pico that communicates with the sensor via I²C and
+  streams converted magnetic-field and temperature readings over the USB CDC interface.
+* **Host utilities** that run on a Linux-based Raspberry Pi and decode the binary frames
+  produced by the Pico firmware.
+
+The Pico firmware is based on Infineon's generic TLx493D driver library. Measurements are
+converted to millitesla (Bx, By, Bz) and degrees Celsius before transmission.
 
 # Getting Started
-TODO: Guide users through getting your code up and running on their own system. In this section you can talk about:
-1.	Installation process
-2.	Software dependencies
-3.	Latest releases
-4.	API references
 
-# Build and Test
-TODO: Describe and show how to build your code and run the tests. 
+## Firmware prerequisites
+
+* Raspberry Pi Pico SDK 2.0 or newer
+* CMake 3.13+
+* ARM GCC toolchain compatible with the Pico SDK
+
+To build the firmware target:
+
+```bash
+mkdir build
+cd build
+cmake ..
+ninja  # or: make
+```
+
+The resulting UF2 image can be found in the build directory and flashed onto the Pico in
+the usual manner (BOOTSEL + drag-and-drop).
+
+## Host-side reader prerequisites
+
+* GNU g++ with C++17 support
+* A Raspberry Pi (or any Linux host) connected to the Pico via USB
+
+Compile the reader utility directly from the repository root:
+
+```bash
+g++ -std=c++17 -Wall -Wextra -O2 -o pico_usb_reader pico_usb_reader.cpp
+```
+
+The resulting executable listens to the USB CDC device exposed by the Pico (default:
+`/dev/ttyACM0`) and prints decoded measurements to `stdout`.
+
+# Usage
+
+1. Flash the Pico firmware and connect the board via USB.
+2. Build the host utility as described above.
+3. Run the reader and optionally specify the serial device path:
+
+   ```bash
+   ./pico_usb_reader               # Uses /dev/ttyACM0 by default
+   ./pico_usb_reader /dev/ttyACM1  # Explicit device selection
+   ```
+
+The tool validates the CRC-32 checksum embedded in each measurement frame and reports
+sensor readings in human-readable form. Any overflow status packets emitted by the Pico
+are logged to `stderr`.
 
 # Contribute
-TODO: Explain how other users and developers can contribute to make your code better. 
 
-If you want to learn more about creating good readme files then refer the following [guidelines](https://docs.microsoft.com/en-us/azure/devops/repos/git/create-a-readme?view=azure-devops). You can also seek inspiration from the below readme files:
-- [ASP.NET Core](https://github.com/aspnet/Home)
-- [Visual Studio Code](https://github.com/Microsoft/vscode)
-- [Chakra Core](https://github.com/Microsoft/ChakraCore)
+Issues and pull requests that improve the firmware, reader utility, or documentation are
+always welcome. Please describe your use case and test setup when proposing changes so
+that others can reproduce the results.

--- a/pico_usb_reader.cpp
+++ b/pico_usb_reader.cpp
@@ -1,0 +1,284 @@
+#include <array>
+#include <atomic>
+#include <cerrno>
+#include <csignal>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <iomanip>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <unistd.h>
+#include <vector>
+#include <fcntl.h>
+#include <termios.h>
+
+namespace {
+
+constexpr uint32_t kMeasurementPacketMagic = 0x544C564D; // "TLVM"
+constexpr uint32_t kStatusPacketMagic = 0x544C5653;      // "TLVS"
+constexpr std::size_t kMeasurementPacketSize = 36;
+constexpr std::size_t kStatusPacketSize = 12;
+
+uint32_t compute_crc32(const uint8_t *data, std::size_t length)
+{
+    uint32_t crc = 0xFFFFFFFFu;
+    for (std::size_t i = 0; i < length; ++i) {
+        crc ^= data[i];
+        for (int bit = 0; bit < 8; ++bit) {
+            const uint32_t mask = -(crc & 1u);
+            crc = (crc >> 1) ^ (0xEDB88320u & mask);
+        }
+    }
+    return ~crc;
+}
+
+uint32_t read_u32_le(const uint8_t *data)
+{
+    return static_cast<uint32_t>(data[0]) |
+           (static_cast<uint32_t>(data[1]) << 8) |
+           (static_cast<uint32_t>(data[2]) << 16) |
+           (static_cast<uint32_t>(data[3]) << 24);
+}
+
+uint64_t read_u64_le(const uint8_t *data)
+{
+    uint64_t value = 0;
+    for (int i = 7; i >= 0; --i) {
+        value = (value << 8) | data[i];
+    }
+    return value;
+}
+
+float read_float_le(const uint8_t *data)
+{
+    uint32_t raw = read_u32_le(data);
+    float value;
+    std::memcpy(&value, &raw, sizeof(value));
+    return value;
+}
+
+struct MeasurementPacket {
+    uint32_t sequence = 0;
+    uint64_t timestamp_us = 0;
+    float bx_mT = 0.0f;
+    float by_mT = 0.0f;
+    float bz_mT = 0.0f;
+    float temperature_C = 0.0f;
+};
+
+struct StatusPacket {
+    uint32_t overflow_count = 0;
+};
+
+enum class PacketType {
+    Measurement,
+    Status,
+};
+
+struct Packet {
+    PacketType type;
+    MeasurementPacket measurement{};
+    StatusPacket status{};
+};
+
+std::optional<Packet> try_decode_packet(std::vector<uint8_t> &buffer)
+{
+    // Ensure we have at least a magic field to inspect.
+    while (buffer.size() >= sizeof(uint32_t)) {
+        uint32_t magic = read_u32_le(buffer.data());
+
+        if (magic == kMeasurementPacketMagic) {
+            if (buffer.size() < kMeasurementPacketSize) {
+                return std::nullopt;
+            }
+
+            const uint32_t expected_crc = read_u32_le(buffer.data() + kMeasurementPacketSize - sizeof(uint32_t));
+            const uint32_t computed_crc = compute_crc32(buffer.data(), kMeasurementPacketSize - sizeof(uint32_t));
+            if (expected_crc != computed_crc) {
+                buffer.erase(buffer.begin());
+                continue;
+            }
+
+            MeasurementPacket measurement;
+            measurement.sequence = read_u32_le(buffer.data() + 4);
+            measurement.timestamp_us = read_u64_le(buffer.data() + 8);
+            measurement.bx_mT = read_float_le(buffer.data() + 16);
+            measurement.by_mT = read_float_le(buffer.data() + 20);
+            measurement.bz_mT = read_float_le(buffer.data() + 24);
+            measurement.temperature_C = read_float_le(buffer.data() + 28);
+
+            buffer.erase(buffer.begin(), buffer.begin() + static_cast<std::ptrdiff_t>(kMeasurementPacketSize));
+
+            Packet packet{PacketType::Measurement};
+            packet.measurement = measurement;
+            return packet;
+        }
+
+        if (magic == kStatusPacketMagic) {
+            if (buffer.size() < kStatusPacketSize) {
+                return std::nullopt;
+            }
+
+            const uint32_t expected_crc = read_u32_le(buffer.data() + kStatusPacketSize - sizeof(uint32_t));
+            const uint32_t computed_crc = compute_crc32(buffer.data(), kStatusPacketSize - sizeof(uint32_t));
+            if (expected_crc != computed_crc) {
+                buffer.erase(buffer.begin());
+                continue;
+            }
+
+            StatusPacket status;
+            status.overflow_count = read_u32_le(buffer.data() + 4);
+
+            buffer.erase(buffer.begin(), buffer.begin() + static_cast<std::ptrdiff_t>(kStatusPacketSize));
+
+            Packet packet{PacketType::Status};
+            packet.status = status;
+            return packet;
+        }
+
+        // Unknown magic: drop one byte and continue searching.
+        buffer.erase(buffer.begin());
+    }
+
+    return std::nullopt;
+}
+
+class SerialStream {
+public:
+    SerialStream(std::string device_path, speed_t baud)
+    {
+        fd_ = ::open(device_path.c_str(), O_RDWR | O_NOCTTY | O_SYNC);
+        if (fd_ < 0) {
+            throw std::system_error(errno, std::generic_category(), "Failed to open serial device");
+        }
+
+        termios tty{};
+        if (tcgetattr(fd_, &tty) != 0) {
+            throw std::system_error(errno, std::generic_category(), "tcgetattr failed");
+        }
+
+        cfmakeraw(&tty);
+        tty.c_cflag |= (CLOCAL | CREAD);
+        tty.c_cflag &= ~CRTSCTS;
+        tty.c_cc[VMIN] = 1;
+        tty.c_cc[VTIME] = 0;
+
+        if (cfsetispeed(&tty, baud) != 0 || cfsetospeed(&tty, baud) != 0) {
+            throw std::system_error(errno, std::generic_category(), "Failed to set baud rate");
+        }
+
+        if (tcsetattr(fd_, TCSANOW, &tty) != 0) {
+            throw std::system_error(errno, std::generic_category(), "tcsetattr failed");
+        }
+    }
+
+    ~SerialStream()
+    {
+        if (fd_ >= 0) {
+            ::close(fd_);
+        }
+    }
+
+    SerialStream(const SerialStream &) = delete;
+    SerialStream &operator=(const SerialStream &) = delete;
+
+    ssize_t read(uint8_t *buffer, std::size_t length)
+    {
+        while (true) {
+            ssize_t result = ::read(fd_, buffer, length);
+            if (result >= 0) {
+                return result;
+            }
+
+            if (errno == EINTR) {
+                continue;
+            }
+
+            throw std::system_error(errno, std::generic_category(), "Serial read failed");
+        }
+    }
+
+private:
+    int fd_ = -1;
+};
+
+std::atomic<bool> g_keep_running{true};
+
+void handle_signal(int signal)
+{
+    if (signal == SIGINT || signal == SIGTERM) {
+        g_keep_running.store(false);
+    }
+}
+
+void install_signal_handlers()
+{
+    std::signal(SIGINT, handle_signal);
+    std::signal(SIGTERM, handle_signal);
+}
+
+void print_measurement(const MeasurementPacket &m)
+{
+    const double timestamp_seconds = static_cast<double>(m.timestamp_us) / 1'000'000.0;
+
+    std::cout << std::fixed << std::setprecision(3)
+              << "seq=" << m.sequence
+              << " t=" << timestamp_seconds << "s"
+              << " Bx=" << m.bx_mT << "mT"
+              << " By=" << m.by_mT << "mT"
+              << " Bz=" << m.bz_mT << "mT"
+              << " Temp=" << m.temperature_C << "C"
+              << std::endl;
+}
+
+void print_status(const StatusPacket &status)
+{
+    std::cerr << "[INFO] Dropped measurements reported by Pico: " << status.overflow_count << std::endl;
+}
+
+} // namespace
+
+int main(int argc, char *argv[])
+{
+    try {
+        std::string device = "/dev/ttyACM0";
+        if (argc > 1) {
+            device = argv[1];
+        }
+
+        install_signal_handlers();
+
+        SerialStream serial(device, B115200);
+        std::vector<uint8_t> rx_buffer;
+        rx_buffer.reserve(4096);
+        std::array<uint8_t, 1024> scratch{};
+
+        while (g_keep_running.load()) {
+            ssize_t bytes_read = serial.read(scratch.data(), scratch.size());
+            if (bytes_read == 0) {
+                continue;
+            }
+
+            rx_buffer.insert(rx_buffer.end(), scratch.begin(),
+                             scratch.begin() + static_cast<std::size_t>(bytes_read));
+
+            while (auto packet = try_decode_packet(rx_buffer)) {
+                if (packet->type == PacketType::Measurement) {
+                    print_measurement(packet->measurement);
+                } else {
+                    print_status(packet->status);
+                }
+            }
+        }
+
+        return 0;
+    } catch (const std::exception &ex) {
+        std::cerr << "Error: " << ex.what() << std::endl;
+        return 1;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a Linux-hosted C++ utility that reads the Pico's USB CDC stream and decodes TLV measurement frames
- validate packet CRCs, report magnetic field and temperature values, and surface overflow status updates
- document firmware build steps and host utility usage in the README

## Testing
- g++ -std=c++17 -Wall -Wextra -pedantic -O2 -o pico_usb_reader pico_usb_reader.cpp

------
https://chatgpt.com/codex/tasks/task_e_68cc56f180688332a8a5c06573a64f99